### PR TITLE
✨ #42 Add support for provisioning only a single NAT Gateway

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,13 +88,13 @@ resource "aws_subnet" "public" {
 
 resource "aws_eip" "nateip" {
   vpc   = true
-  count = "${length(var.azs) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
+  count = "${(var.single_nat_gateway ? 1 : length(var.azs)) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
 }
 
 resource "aws_nat_gateway" "natgw" {
-  allocation_id = "${element(aws_eip.nateip.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  count         = "${length(var.azs) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
+  allocation_id = "${element(aws_eip.nateip.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  subnet_id     = "${element(aws_subnet.public.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  count         = "${(var.single_nat_gateway ? 1 : length(var.azs)) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
 
   depends_on = ["aws_internet_gateway.mod"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "single_nat_gateway" {
+  description = "should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  default     = false
+}
+
 variable "enable_s3_endpoint" {
   description = "should be true if you want to provision an S3 endpoint to the VPC"
   default     = false


### PR DESCRIPTION
**DEPENDENT ON PR #57**

# Sample setup:
  * You have 2 public subnets
  * You have 2 private subnets

## Scenario 1 (high availability)
Prior to this change when you set `enable_nat_gateway=true` you would get the following infrastructure:
  * 2 EIPs (_1 per private subnet_)
  * 2 NAT Gateway (_1 per private subnet_)

While this follows high availability best practices and _should be_ your configuration in a production, sometimes you don't want to incur the cost of having multiple NAT gateways in your dev and testing environments.

## Scenario 2 (low availability)
After this change when you set `enable_nat_gateway=true` and `single_nat_gateway=true` you would get the following infrastructure:
  * 1 EIP (_1 total_)
  * 1 NAT Gateway (_1 total_)

Meaning that you share a single EIP/NAT gateway pairing across all of your private subnets. Reducing costs while maintaining functionality but being far less available. This leaves the onus on the person terraforming to decide whether or not they are ok with the cost/risk tradeoff. 

**Again, this scenario is not intended for a production environment.**
